### PR TITLE
Patches 1440 - Zendframework URL Rewrite vulnerability

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/AbstractCallback.php
+++ b/library/Zend/Feed/PubSubHubbub/AbstractCallback.php
@@ -198,28 +198,32 @@ abstract class AbstractCallback implements CallbackInterface
      */
     protected function _detectCallbackUrl()
     {
-        $callbackUrl = '';
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
-            $callbackUrl = $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-            $callbackUrl = $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
-            $callbackUrl = $_SERVER['REQUEST_URI'];
-            $scheme = 'http';
-            if ($_SERVER['HTTPS'] == 'on') {
-                $scheme = 'https';
-            }
-            $schemeAndHttpHost = $scheme . '://' . $this->_getHttpHost();
-            if (strpos($callbackUrl, $schemeAndHttpHost) === 0) {
-                $callbackUrl = substr($callbackUrl, strlen($schemeAndHttpHost));
-            }
-        } elseif (isset($_SERVER['ORIG_PATH_INFO'])) {
-            $callbackUrl= $_SERVER['ORIG_PATH_INFO'];
-            if (!empty($_SERVER['QUERY_STRING'])) {
-                $callbackUrl .= '?' . $_SERVER['QUERY_STRING'];
-            }
+        // @codingStandardsIgnoreEnd
+        $callbackUrl = null;
+
+        // IIS7 with URL Rewrite: make sure we get the unencoded url
+        // (double slash problem).
+        $iisUrlRewritten = isset($_SERVER['IIS_WasUrlRewritten']) ? $_SERVER['IIS_WasUrlRewritten'] : null;
+        $unencodedUrl    = isset($_SERVER['UNENCODED_URL']) ? $_SERVER['UNENCODED_URL'] : null;
+        if ('1' == $iisUrlRewritten && ! empty($unencodedUrl)) {
+            return $unencodedUrl;
         }
-        return $callbackUrl;
+
+        // HTTP proxy requests setup request URI with scheme and host [and port]
+        // + the URL path, only use URL path.
+        if (isset($_SERVER['REQUEST_URI'])) {
+            $callbackUrl = $this->buildCallbackUrlFromRequestUri();
+        }
+
+        if (null !== $callbackUrl) {
+            return $callbackUrl;
+        }
+
+        if (isset($_SERVER['ORIG_PATH_INFO'])) {
+            return $this->buildCallbackUrlFromOrigPathInfo();
+        }
+
+        return '';
     }
 
     /**
@@ -229,22 +233,23 @@ abstract class AbstractCallback implements CallbackInterface
      */
     protected function _getHttpHost()
     {
-        if (!empty($_SERVER['HTTP_HOST'])) {
+        // @codingStandardsIgnoreEnd
+        if (! empty($_SERVER['HTTP_HOST'])) {
             return $_SERVER['HTTP_HOST'];
         }
-        $scheme = 'http';
-        if ($_SERVER['HTTPS'] == 'on') {
-            $scheme = 'https';
-        }
-        $name = $_SERVER['SERVER_NAME'];
-        $port = $_SERVER['SERVER_PORT'];
-        if (($scheme == 'http' && $port == 80)
-            || ($scheme == 'https' && $port == 443)
+
+        $https  = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : null;
+        $scheme = $https === 'on' ? 'https' : 'http';
+        $name   = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
+        $port   = isset($_SERVER['SERVER_PORT']) ? (int) $_SERVER['SERVER_PORT'] : 80;
+
+        if (($scheme === 'http' && $port === 80)
+            || ($scheme === 'https' && $port === 443)
         ) {
             return $name;
         }
 
-        return $name . ':' . $port;
+        return sprintf('%s:%d', $name, $port);
     }
 
     /**
@@ -288,4 +293,39 @@ abstract class AbstractCallback implements CallbackInterface
         }
         return false;
     }
+
+    /**
+     * Build the callback URL from the REQUEST_URI server parameter.
+     *
+     * @return string
+     */
+    private function buildCallbackUrlFromRequestUri()
+    {
+        $callbackUrl = $_SERVER['REQUEST_URI'];
+        $https = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : null;
+        $scheme = $https === 'on' ? 'https' : 'http';
+        if ($https === 'on') {
+            $scheme = 'https';
+        }
+        $schemeAndHttpHost = $scheme . '://' . $this->_getHttpHost();
+        if (strpos($callbackUrl, $schemeAndHttpHost) === 0) {
+            $callbackUrl = substr($callbackUrl, strlen($schemeAndHttpHost));
+        }
+        return $callbackUrl;
+    }
+
+    /**
+     * Build the callback URL from the ORIG_PATH_INFO server parameter.
+     *
+     * @return string
+     */
+    private function buildCallbackUrlFromOrigPathInfo()
+    {
+        $callbackUrl = $_SERVER['ORIG_PATH_INFO'];
+        if (! empty($_SERVER['QUERY_STRING'])) {
+            $callbackUrl .= '?' . $_SERVER['QUERY_STRING'];
+        }
+        return $callbackUrl;
+    }
+
 }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -436,18 +436,6 @@ class Request extends HttpRequest
         $requestUri = null;
         $server     = $this->getServer();
 
-        // Check this first so IIS will catch.
-        $httpXRewriteUrl = $server->get('HTTP_X_REWRITE_URL');
-        if ($httpXRewriteUrl !== null) {
-            $requestUri = $httpXRewriteUrl;
-        }
-
-        // Check for IIS 7.0 or later with ISAPI_Rewrite
-        $httpXOriginalUrl = $server->get('HTTP_X_ORIGINAL_URL');
-        if ($httpXOriginalUrl !== null) {
-            $requestUri = $httpXOriginalUrl;
-        }
-
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
         $iisUrlRewritten = $server->get('IIS_WasUrlRewritten');
@@ -456,11 +444,10 @@ class Request extends HttpRequest
             return $unencodedUrl;
         }
 
+        $requestUri = $server->get('REQUEST_URI');
+
         // HTTP proxy requests setup request URI with scheme and host [and port]
         // + the URL path, only use URL path.
-        if (!$httpXRewriteUrl) {
-            $requestUri = $server->get('REQUEST_URI');
-        }
 
         if ($requestUri !== null) {
             return preg_replace('#^[^/:]+://[^/]+#', '', $requestUri);

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -118,15 +118,6 @@ class RequestTest extends TestCase
             ),
             array(
                 array(
-                    'HTTP_X_REWRITE_URL' => '/index.php/news/3?var1=val1&var2=val2',
-                    'PHP_SELF'           => '/index.php/news/3',
-                    'SCRIPT_FILENAME'    => '/var/web/html/index.php',
-                ),
-                '/index.php',
-                ''
-            ),
-            array(
-                array(
                     'ORIG_PATH_INFO'  => '/index.php/news/3',
                     'QUERY_STRING'    => 'var1=val1&var2=val2',
                     'PHP_SELF'        => '/index.php/news/3',


### PR DESCRIPTION
https://www.wiz.io/vulnerability-database/cve/ghsa-fh7r-58q4-6387

The vulnerability has been patched in multiple component versions: zend-diactoros 1.8.4, zend-http 2.8.1, and zend-feed 2.10.3.

Zend-Http patch
Copied same code as this commit:
https://github.com/zendframework/zend-http/commit/44197164a270259116162a442f639085ea24094a

Zend-Diactoros does not exist in 2.4.11
https://github.com/zendframework/zend-diactoros/commit/736ffa7c2bfa4a60e8a10acb316fa2ac456c5fba#diff-e5acf70a427ed065a7b5df86fd79f5adf1859c78506aa6d19b3e43b3a052cca9

Zend-Feed patch
Copied same code as this commit:
https://github.com/zendframework/zend-feed/commit/6641f4cf3f4586c63f83fd70b6d19966025c8888